### PR TITLE
feat: Add Table One generator with privacy protection

### DIFF
--- a/clifpy/utils/__init__.py
+++ b/clifpy/utils/__init__.py
@@ -15,6 +15,13 @@ from .waterfall import process_resp_support_waterfall
 from .stitching_encounters import stitch_encounters
 from .sofa import compute_sofa, _compute_sofa_from_extremal_values, _agg_extremal_values_by_id
 from .ase import compute_ase
+from .table_one import (
+    TableOneGenerator,
+    PrivacyConfig,
+    VariableConfig,
+    generate_table_one,
+    DEFAULT_CLIF_VARIABLES,
+)
 
 __all__ = [
       # io
@@ -45,4 +52,10 @@ __all__ = [
       # validator (add main functions)
       'validate_dataframe',
       'validate_table',
+      # table_one
+      'TableOneGenerator',
+      'PrivacyConfig',
+      'VariableConfig',
+      'generate_table_one',
+      'DEFAULT_CLIF_VARIABLES',
   ]

--- a/clifpy/utils/table_one.py
+++ b/clifpy/utils/table_one.py
@@ -1,0 +1,441 @@
+"""
+Table One Generator with Privacy Protection for CLIF.
+
+This module generates standardized Table 1 (baseline characteristics) summaries
+for CLIF cohorts with built-in privacy protection for federated research.
+
+Privacy features:
+- Cell suppression for counts below threshold (default: 10)
+- Optional count rounding to nearest 5 or 10
+- Percentage suppression when denominator is suppressed
+
+Example usage:
+    from clifpy.utils.table_one import TableOneGenerator, PrivacyConfig
+
+    # Configure privacy settings
+    privacy = PrivacyConfig(min_cell_size=10, round_counts_to=5)
+
+    # Generate Table 1
+    generator = TableOneGenerator(cohort_df, privacy_config=privacy)
+    table_one = generator.generate()
+
+    # Export
+    generator.to_csv("output/table_one_SITE.csv")
+    generator.to_json("output/table_one_SITE.json")
+"""
+
+from dataclasses import dataclass, field
+from typing import Optional, List, Dict, Any, Union
+import pandas as pd
+import numpy as np
+from datetime import datetime
+import json
+
+
+@dataclass
+class PrivacyConfig:
+    """Configuration for privacy protection in Table 1 output.
+
+    Attributes:
+        min_cell_size: Minimum count for cell to be reported (default: 10).
+                       Cells below this threshold will be suppressed.
+        round_counts_to: Round all counts to nearest value (e.g., 5 or 10).
+                         Set to None to disable rounding.
+        suppress_percentages: If True, suppress percentages when count is suppressed.
+        suppression_label: Label to use for suppressed cells (default: "<10").
+    """
+
+    min_cell_size: int = 10
+    round_counts_to: Optional[int] = None
+    suppress_percentages: bool = True
+    suppression_label: str = "<10"
+
+    def __post_init__(self):
+        if self.min_cell_size < 1:
+            raise ValueError("min_cell_size must be at least 1")
+        if self.round_counts_to is not None and self.round_counts_to < 1:
+            raise ValueError("round_counts_to must be at least 1 or None")
+
+
+@dataclass
+class VariableConfig:
+    """Configuration for a single variable in Table 1.
+
+    Attributes:
+        name: Column name in the DataFrame.
+        label: Display label for the variable.
+        var_type: Type of variable ('continuous', 'categorical', 'binary').
+        categories: For categorical variables, list of categories to include.
+        summary_stats: For continuous variables, which stats to compute.
+    """
+
+    name: str
+    label: str
+    var_type: str = "continuous"  # 'continuous', 'categorical', 'binary'
+    categories: Optional[List[str]] = None
+    summary_stats: List[str] = field(
+        default_factory=lambda: ["median", "q1", "q3", "missing"]
+    )
+
+
+# Default CLIF Table 1 variables
+DEFAULT_CLIF_VARIABLES = [
+    VariableConfig("age_at_admission", "Age (years)", "continuous"),
+    VariableConfig("sex_category", "Sex", "categorical"),
+    VariableConfig("race_category", "Race", "categorical"),
+    VariableConfig("ethnicity_category", "Ethnicity", "categorical"),
+    VariableConfig("icu_los_hours", "ICU Length of Stay (hours)", "continuous"),
+    VariableConfig("hospital_los_days", "Hospital Length of Stay (days)", "continuous"),
+    VariableConfig(
+        "hospital_mortality", "In-Hospital Mortality", "binary", categories=["Yes", "No"]
+    ),
+    VariableConfig(
+        "received_imv", "Received Invasive Mechanical Ventilation", "binary"
+    ),
+    VariableConfig("received_vasopressors", "Received Vasopressors", "binary"),
+    VariableConfig("received_crrt", "Received CRRT", "binary"),
+]
+
+
+class TableOneGenerator:
+    """Generate standardized Table 1 summaries with privacy protection.
+
+    This class produces Table 1 (baseline characteristics) tables that are
+    safe for sharing in federated research contexts.
+    """
+
+    def __init__(
+        self,
+        data: pd.DataFrame,
+        variables: Optional[List[VariableConfig]] = None,
+        privacy_config: Optional[PrivacyConfig] = None,
+        site_name: Optional[str] = None,
+        cohort_description: Optional[str] = None,
+    ):
+        """Initialize the Table One generator.
+
+        Args:
+            data: DataFrame containing the cohort data.
+            variables: List of VariableConfig objects defining variables to summarize.
+                       If None, uses DEFAULT_CLIF_VARIABLES.
+            privacy_config: Privacy settings. If None, uses default PrivacyConfig.
+            site_name: Name of the site (for output labeling).
+            cohort_description: Description of the cohort for metadata.
+        """
+        self.data = data
+        self.variables = variables or DEFAULT_CLIF_VARIABLES
+        self.privacy = privacy_config or PrivacyConfig()
+        self.site_name = site_name or "SITE"
+        self.cohort_description = cohort_description
+        self._results: Optional[pd.DataFrame] = None
+        self._metadata: Dict[str, Any] = {}
+
+    def _apply_privacy(self, count: int) -> Union[int, str]:
+        """Apply privacy protection to a count.
+
+        Returns the count (possibly rounded) or suppression label if below threshold.
+        """
+        if count < self.privacy.min_cell_size:
+            return self.privacy.suppression_label
+
+        if self.privacy.round_counts_to:
+            return (
+                round(count / self.privacy.round_counts_to)
+                * self.privacy.round_counts_to
+            )
+
+        return count
+
+    def _calculate_percentage(
+        self, count: Union[int, str], total: int
+    ) -> Union[float, str]:
+        """Calculate percentage with privacy protection."""
+        if isinstance(count, str):  # Suppressed
+            return self.privacy.suppression_label if self.privacy.suppress_percentages else ""
+        if total == 0:
+            return 0.0
+        return round(100 * count / total, 1)
+
+    def _summarize_continuous(
+        self, series: pd.Series, config: VariableConfig
+    ) -> Dict[str, Any]:
+        """Summarize a continuous variable."""
+        result = {"variable": config.label, "type": "continuous"}
+
+        # Calculate stats on non-missing values
+        valid = series.dropna()
+        n_total = len(series)
+        n_valid = len(valid)
+        n_missing = n_total - n_valid
+
+        # Apply privacy to counts
+        result["n"] = self._apply_privacy(n_valid)
+        result["missing_n"] = self._apply_privacy(n_missing)
+        result["missing_pct"] = self._calculate_percentage(n_missing, n_total)
+
+        # Only report statistics if we have enough non-suppressed data
+        if isinstance(result["n"], int) and n_valid >= self.privacy.min_cell_size:
+            if "median" in config.summary_stats:
+                result["median"] = round(valid.median(), 1)
+            if "mean" in config.summary_stats:
+                result["mean"] = round(valid.mean(), 1)
+            if "std" in config.summary_stats:
+                result["std"] = round(valid.std(), 1)
+            if "q1" in config.summary_stats:
+                result["q1"] = round(valid.quantile(0.25), 1)
+            if "q3" in config.summary_stats:
+                result["q3"] = round(valid.quantile(0.75), 1)
+            if "min" in config.summary_stats:
+                result["min"] = round(valid.min(), 1)
+            if "max" in config.summary_stats:
+                result["max"] = round(valid.max(), 1)
+        else:
+            # Suppress statistics if count is suppressed
+            for stat in ["median", "mean", "std", "q1", "q3", "min", "max"]:
+                if stat in config.summary_stats:
+                    result[stat] = self.privacy.suppression_label
+
+        return result
+
+    def _summarize_categorical(
+        self, series: pd.Series, config: VariableConfig
+    ) -> List[Dict[str, Any]]:
+        """Summarize a categorical variable."""
+        results = []
+        n_total = len(series)
+
+        # Get value counts
+        counts = series.value_counts(dropna=False)
+
+        # Determine categories to report
+        if config.categories:
+            categories = config.categories
+        else:
+            categories = [c for c in counts.index if pd.notna(c)]
+
+        for cat in categories:
+            count = counts.get(cat, 0)
+            protected_count = self._apply_privacy(count)
+
+            results.append(
+                {
+                    "variable": config.label,
+                    "category": str(cat),
+                    "type": "categorical",
+                    "n": protected_count,
+                    "pct": self._calculate_percentage(protected_count, n_total),
+                }
+            )
+
+        # Add missing count
+        missing_count = counts.get(np.nan, 0) + (
+            n_total - counts.sum() if pd.isna(counts.index).any() else 0
+        )
+        if missing_count > 0 or True:  # Always include missing row
+            missing_count = series.isna().sum()
+            results.append(
+                {
+                    "variable": config.label,
+                    "category": "Missing",
+                    "type": "categorical",
+                    "n": self._apply_privacy(missing_count),
+                    "pct": self._calculate_percentage(
+                        self._apply_privacy(missing_count), n_total
+                    ),
+                }
+            )
+
+        return results
+
+    def _summarize_binary(
+        self, series: pd.Series, config: VariableConfig
+    ) -> List[Dict[str, Any]]:
+        """Summarize a binary variable."""
+        n_total = len(series)
+
+        # Handle different binary representations
+        if series.dtype == bool:
+            n_yes = series.sum()
+        elif series.dtype in ["int64", "float64"]:
+            n_yes = (series == 1).sum()
+        else:
+            # Try to detect yes/true values
+            yes_values = ["yes", "Yes", "YES", "true", "True", "TRUE", "1", 1, True]
+            n_yes = series.isin(yes_values).sum()
+
+        n_no = n_total - n_yes - series.isna().sum()
+        n_missing = series.isna().sum()
+
+        results = [
+            {
+                "variable": config.label,
+                "category": "Yes",
+                "type": "binary",
+                "n": self._apply_privacy(n_yes),
+                "pct": self._calculate_percentage(self._apply_privacy(n_yes), n_total),
+            },
+            {
+                "variable": config.label,
+                "category": "No",
+                "type": "binary",
+                "n": self._apply_privacy(n_no),
+                "pct": self._calculate_percentage(self._apply_privacy(n_no), n_total),
+            },
+        ]
+
+        if n_missing > 0:
+            results.append(
+                {
+                    "variable": config.label,
+                    "category": "Missing",
+                    "type": "binary",
+                    "n": self._apply_privacy(n_missing),
+                    "pct": self._calculate_percentage(
+                        self._apply_privacy(n_missing), n_total
+                    ),
+                }
+            )
+
+        return results
+
+    def generate(self) -> pd.DataFrame:
+        """Generate the Table 1 summary.
+
+        Returns:
+            DataFrame containing the Table 1 summary with privacy protection applied.
+        """
+        rows = []
+
+        # Add total N row
+        total_n = len(self.data)
+        rows.append(
+            {
+                "variable": "Total N",
+                "category": "",
+                "type": "count",
+                "n": self._apply_privacy(total_n),
+                "pct": 100.0,
+            }
+        )
+
+        # Process each variable
+        for var_config in self.variables:
+            if var_config.name not in self.data.columns:
+                continue  # Skip variables not in the data
+
+            series = self.data[var_config.name]
+
+            if var_config.var_type == "continuous":
+                row = self._summarize_continuous(series, var_config)
+                rows.append(row)
+            elif var_config.var_type == "categorical":
+                rows.extend(self._summarize_categorical(series, var_config))
+            elif var_config.var_type == "binary":
+                rows.extend(self._summarize_binary(series, var_config))
+
+        self._results = pd.DataFrame(rows)
+
+        # Store metadata
+        self._metadata = {
+            "site_name": self.site_name,
+            "cohort_description": self.cohort_description,
+            "generated_at": datetime.now().isoformat(),
+            "privacy_config": {
+                "min_cell_size": self.privacy.min_cell_size,
+                "round_counts_to": self.privacy.round_counts_to,
+                "suppress_percentages": self.privacy.suppress_percentages,
+            },
+            "total_n_raw": total_n,  # Store raw N for internal use
+            "variables_included": [v.name for v in self.variables if v.name in self.data.columns],
+            "variables_missing": [v.name for v in self.variables if v.name not in self.data.columns],
+        }
+
+        return self._results
+
+    def get_metadata(self) -> Dict[str, Any]:
+        """Get metadata about the generated table."""
+        if not self._metadata:
+            raise ValueError("Must call generate() before getting metadata")
+        return self._metadata
+
+    def to_csv(self, path: str, include_metadata: bool = True) -> None:
+        """Export Table 1 to CSV.
+
+        Args:
+            path: Output file path.
+            include_metadata: If True, includes metadata rows at the top.
+        """
+        if self._results is None:
+            self.generate()
+
+        if include_metadata:
+            # Write metadata as comments
+            with open(path, "w") as f:
+                f.write(f"# Site: {self._metadata['site_name']}\n")
+                f.write(f"# Generated: {self._metadata['generated_at']}\n")
+                f.write(f"# Min Cell Size: {self._metadata['privacy_config']['min_cell_size']}\n")
+                if self._metadata["cohort_description"]:
+                    f.write(f"# Cohort: {self._metadata['cohort_description']}\n")
+                f.write("#\n")
+                self._results.to_csv(f, index=False)
+        else:
+            self._results.to_csv(path, index=False)
+
+    def to_json(self, path: str) -> None:
+        """Export Table 1 to JSON with full metadata.
+
+        Args:
+            path: Output file path.
+        """
+        if self._results is None:
+            self.generate()
+
+        output = {
+            "metadata": self._metadata,
+            "table_one": self._results.to_dict(orient="records"),
+        }
+
+        with open(path, "w") as f:
+            json.dump(output, f, indent=2, default=str)
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Return Table 1 as a dictionary.
+
+        Returns:
+            Dictionary with 'metadata' and 'table_one' keys.
+        """
+        if self._results is None:
+            self.generate()
+
+        return {
+            "metadata": self._metadata,
+            "table_one": self._results.to_dict(orient="records"),
+        }
+
+
+def generate_table_one(
+    data: pd.DataFrame,
+    variables: Optional[List[VariableConfig]] = None,
+    min_cell_size: int = 10,
+    round_counts_to: Optional[int] = None,
+    site_name: Optional[str] = None,
+) -> pd.DataFrame:
+    """Convenience function to generate Table 1 with default settings.
+
+    Args:
+        data: DataFrame containing the cohort data.
+        variables: List of VariableConfig objects. If None, uses CLIF defaults.
+        min_cell_size: Minimum cell size for privacy (default: 10).
+        round_counts_to: Round counts to nearest value (optional).
+        site_name: Name of the site.
+
+    Returns:
+        DataFrame containing the Table 1 summary.
+
+    Example:
+        >>> table1 = generate_table_one(cohort_df, site_name="UCMC")
+        >>> table1.to_csv("table_one_UCMC.csv")
+    """
+    privacy = PrivacyConfig(min_cell_size=min_cell_size, round_counts_to=round_counts_to)
+    generator = TableOneGenerator(data, variables=variables, privacy_config=privacy, site_name=site_name)
+    return generator.generate()

--- a/tests/test_table_one.py
+++ b/tests/test_table_one.py
@@ -1,0 +1,260 @@
+"""Tests for Table One generator with privacy protection."""
+
+import pytest
+import pandas as pd
+import numpy as np
+import json
+import tempfile
+from pathlib import Path
+
+from clifpy.utils.table_one import (
+    TableOneGenerator,
+    PrivacyConfig,
+    VariableConfig,
+    generate_table_one,
+    DEFAULT_CLIF_VARIABLES,
+)
+
+
+@pytest.fixture
+def sample_cohort():
+    """Create a sample cohort DataFrame for testing."""
+    np.random.seed(42)
+    n = 100
+    return pd.DataFrame({
+        "hospitalization_id": range(n),
+        "age_at_admission": np.random.normal(65, 15, n),
+        "sex_category": np.random.choice(["Male", "Female"], n),
+        "race_category": np.random.choice(
+            ["White", "Black", "Asian", "Other", None], n, p=[0.6, 0.2, 0.1, 0.05, 0.05]
+        ),
+        "ethnicity_category": np.random.choice(
+            ["Non-Hispanic", "Hispanic", None], n, p=[0.8, 0.15, 0.05]
+        ),
+        "icu_los_hours": np.random.exponential(48, n),
+        "hospital_los_days": np.random.exponential(7, n),
+        "hospital_mortality": np.random.choice([0, 1], n, p=[0.85, 0.15]),
+        "received_imv": np.random.choice([0, 1], n, p=[0.7, 0.3]),
+        "received_vasopressors": np.random.choice([0, 1], n, p=[0.6, 0.4]),
+        "received_crrt": np.random.choice([0, 1], n, p=[0.95, 0.05]),
+    })
+
+
+@pytest.fixture
+def small_cohort():
+    """Create a small cohort to test privacy suppression."""
+    return pd.DataFrame({
+        "hospitalization_id": range(15),
+        "age_at_admission": [60, 65, 70, 55, 80, 45, 72, 68, 63, 58, 75, 82, 67, 71, 59],
+        "sex_category": ["Male"] * 12 + ["Female"] * 3,  # Female count < 10
+        "rare_category": ["Common"] * 14 + ["Rare"],  # Rare count = 1
+        "hospital_mortality": [0] * 14 + [1],  # Mortality = 1
+    })
+
+
+class TestPrivacyConfig:
+    """Tests for PrivacyConfig."""
+
+    def test_default_config(self):
+        config = PrivacyConfig()
+        assert config.min_cell_size == 10
+        assert config.round_counts_to is None
+        assert config.suppress_percentages is True
+        assert config.suppression_label == "<10"
+
+    def test_custom_config(self):
+        config = PrivacyConfig(min_cell_size=5, round_counts_to=5, suppression_label="<5")
+        assert config.min_cell_size == 5
+        assert config.round_counts_to == 5
+        assert config.suppression_label == "<5"
+
+    def test_invalid_min_cell_size(self):
+        with pytest.raises(ValueError, match="min_cell_size must be at least 1"):
+            PrivacyConfig(min_cell_size=0)
+
+    def test_invalid_round_counts_to(self):
+        with pytest.raises(ValueError, match="round_counts_to must be at least 1"):
+            PrivacyConfig(round_counts_to=0)
+
+
+class TestTableOneGenerator:
+    """Tests for TableOneGenerator."""
+
+    def test_basic_generation(self, sample_cohort):
+        generator = TableOneGenerator(sample_cohort, site_name="TEST")
+        result = generator.generate()
+
+        assert isinstance(result, pd.DataFrame)
+        assert len(result) > 0
+        assert "variable" in result.columns
+        assert "n" in result.columns
+
+    def test_total_n_included(self, sample_cohort):
+        generator = TableOneGenerator(sample_cohort)
+        result = generator.generate()
+
+        total_row = result[result["variable"] == "Total N"]
+        assert len(total_row) == 1
+        assert total_row.iloc[0]["n"] == 100
+
+    def test_privacy_suppression(self, small_cohort):
+        """Test that small counts are suppressed."""
+        privacy = PrivacyConfig(min_cell_size=10)
+        variables = [
+            VariableConfig("sex_category", "Sex", "categorical"),
+        ]
+        generator = TableOneGenerator(
+            small_cohort, variables=variables, privacy_config=privacy
+        )
+        result = generator.generate()
+
+        # Female count (3) should be suppressed
+        female_row = result[
+            (result["variable"] == "Sex") & (result["category"] == "Female")
+        ]
+        assert female_row.iloc[0]["n"] == "<10"
+
+        # Male count (12) should not be suppressed
+        male_row = result[
+            (result["variable"] == "Sex") & (result["category"] == "Male")
+        ]
+        assert male_row.iloc[0]["n"] == 12
+
+    def test_count_rounding(self, sample_cohort):
+        """Test count rounding for privacy."""
+        privacy = PrivacyConfig(round_counts_to=5)
+        generator = TableOneGenerator(
+            sample_cohort, privacy_config=privacy, site_name="TEST"
+        )
+        result = generator.generate()
+
+        # All counts should be divisible by 5
+        for _, row in result.iterrows():
+            n = row.get("n")
+            if isinstance(n, (int, float)) and not isinstance(n, str):
+                assert n % 5 == 0, f"Count {n} not rounded to nearest 5"
+
+    def test_continuous_variable_summary(self, sample_cohort):
+        """Test continuous variable summarization."""
+        variables = [VariableConfig("age_at_admission", "Age", "continuous")]
+        generator = TableOneGenerator(sample_cohort, variables=variables)
+        result = generator.generate()
+
+        age_row = result[result["variable"] == "Age"].iloc[0]
+        assert "median" in age_row
+        assert "q1" in age_row
+        assert "q3" in age_row
+        assert isinstance(age_row["median"], (int, float))
+
+    def test_binary_variable_summary(self, sample_cohort):
+        """Test binary variable summarization."""
+        variables = [VariableConfig("hospital_mortality", "Mortality", "binary")]
+        generator = TableOneGenerator(sample_cohort, variables=variables)
+        result = generator.generate()
+
+        yes_row = result[
+            (result["variable"] == "Mortality") & (result["category"] == "Yes")
+        ]
+        no_row = result[
+            (result["variable"] == "Mortality") & (result["category"] == "No")
+        ]
+        assert len(yes_row) == 1
+        assert len(no_row) == 1
+
+    def test_missing_variable_handled(self, sample_cohort):
+        """Test that missing variables in data are skipped gracefully."""
+        variables = [
+            VariableConfig("age_at_admission", "Age", "continuous"),
+            VariableConfig("nonexistent_column", "Missing", "continuous"),
+        ]
+        generator = TableOneGenerator(sample_cohort, variables=variables)
+        result = generator.generate()
+
+        # Should only have Total N and Age rows
+        variables_in_result = result["variable"].unique()
+        assert "Missing" not in variables_in_result
+        assert "Age" in variables_in_result
+
+    def test_metadata_generation(self, sample_cohort):
+        """Test metadata is properly generated."""
+        generator = TableOneGenerator(
+            sample_cohort,
+            site_name="UCMC",
+            cohort_description="Test cohort",
+        )
+        generator.generate()
+        metadata = generator.get_metadata()
+
+        assert metadata["site_name"] == "UCMC"
+        assert metadata["cohort_description"] == "Test cohort"
+        assert "generated_at" in metadata
+        assert "privacy_config" in metadata
+
+    def test_csv_export(self, sample_cohort, tmp_path):
+        """Test CSV export functionality."""
+        generator = TableOneGenerator(sample_cohort, site_name="TEST")
+        generator.generate()
+
+        output_path = tmp_path / "table_one.csv"
+        generator.to_csv(str(output_path))
+
+        assert output_path.exists()
+        # Read back and verify
+        df = pd.read_csv(output_path, comment="#")
+        assert len(df) > 0
+
+    def test_json_export(self, sample_cohort, tmp_path):
+        """Test JSON export functionality."""
+        generator = TableOneGenerator(sample_cohort, site_name="TEST")
+        generator.generate()
+
+        output_path = tmp_path / "table_one.json"
+        generator.to_json(str(output_path))
+
+        assert output_path.exists()
+        with open(output_path) as f:
+            data = json.load(f)
+        assert "metadata" in data
+        assert "table_one" in data
+
+    def test_to_dict(self, sample_cohort):
+        """Test dictionary export."""
+        generator = TableOneGenerator(sample_cohort)
+        generator.generate()
+        result = generator.to_dict()
+
+        assert "metadata" in result
+        assert "table_one" in result
+        assert isinstance(result["table_one"], list)
+
+
+class TestConvenienceFunction:
+    """Tests for generate_table_one convenience function."""
+
+    def test_basic_usage(self, sample_cohort):
+        result = generate_table_one(sample_cohort, site_name="TEST")
+        assert isinstance(result, pd.DataFrame)
+        assert len(result) > 0
+
+    def test_with_privacy_params(self, sample_cohort):
+        result = generate_table_one(
+            sample_cohort,
+            min_cell_size=5,
+            round_counts_to=10,
+            site_name="TEST",
+        )
+        assert isinstance(result, pd.DataFrame)
+
+
+class TestDefaultVariables:
+    """Tests for default CLIF variables."""
+
+    def test_default_variables_defined(self):
+        assert len(DEFAULT_CLIF_VARIABLES) > 0
+        assert all(isinstance(v, VariableConfig) for v in DEFAULT_CLIF_VARIABLES)
+
+    def test_default_variables_have_required_fields(self):
+        for var in DEFAULT_CLIF_VARIABLES:
+            assert var.name is not None
+            assert var.label is not None
+            assert var.var_type in ["continuous", "categorical", "binary"]


### PR DESCRIPTION
## Summary

This PR adds a standardized Table 1 (baseline characteristics) generator with built-in privacy protection for federated research.

## Features

- **TableOneGenerator** class for generating Table 1 summaries
- **PrivacyConfig** with cell suppression (default min_cell_size=10) and optional count rounding
- Support for continuous, categorical, and binary variable types
- **DEFAULT_CLIF_VARIABLES** for common ICU characteristics
- CSV and JSON export with metadata
- Comprehensive test suite

## Privacy Protection

- Cell counts below threshold are suppressed (displayed as `<10`)
- Optional count rounding to nearest 5 or 10
- Percentage suppression when underlying count is suppressed
- Metadata tracks privacy settings for audit

## Usage

```python
from clifpy.utils.table_one import TableOneGenerator, PrivacyConfig

privacy = PrivacyConfig(min_cell_size=10, round_counts_to=5)
generator = TableOneGenerator(cohort_df, privacy_config=privacy, site_name="UCMC")
table1 = generator.generate()
generator.to_csv("table_one_UCMC.csv")
```

## Why This Matters

This enables sites to generate consistent, privacy-safe Table 1 outputs for federated research where only aggregates are shared.

---

*First PR from Clifford - CLIF AI assistant* 🏥