### PR TITLE
proposed fix for issue #144

### DIFF
--- a/clifpy/utils/unit_converter.py
+++ b/clifpy/utils/unit_converter.py
@@ -17,6 +17,10 @@ from clifpy.utils.logging_config import get_logger
 
 logger = get_logger('utils.unit_converter')
 
+# DuckDB converts TIMESTAMPTZ columns to the local system timezone on .to_df().
+# Setting TimeZone to UTC on the default connection prevents this.
+duckdb.sql("SET TimeZone = 'UTC'")
+
 UNIT_NAMING_VARIANTS = {
     # time
     '/hr': '/h(r|our)?$',


### PR DESCRIPTION
Closes https://github.com/Common-Longitudinal-ICU-data-Format/clifpy/issues/144

This pull request makes a small but important change to the `clifpy/utils/unit_converter.py` file by ensuring that all TIMESTAMPTZ columns are consistently interpreted in UTC when converting DuckDB query results to pandas DataFrames. This avoids issues with timezone mismatches that could arise from system-dependent defaults.

* Set the DuckDB connection's timezone to UTC by executing `duckdb.sql("SET TimeZone = 'UTC'")` at initialization to ensure consistent handling of TIMESTAMPTZ columns.